### PR TITLE
Change parameter of escape functions from char* to const char*

### DIFF
--- a/cgic.c
+++ b/cgic.c
@@ -2475,7 +2475,7 @@ skipSecondValue2:
 		} \
 	} 
 
-cgiFormResultType cgiHtmlEscapeData(char *data, int len)
+cgiFormResultType cgiHtmlEscapeData(const char *data, int len)
 {
 	while (len--) {
 		if (*data == '<') {
@@ -2502,7 +2502,7 @@ cgiFormResultType cgiHtmlEscapeData(char *data, int len)
 	return cgiFormSuccess;
 }
 
-cgiFormResultType cgiHtmlEscape(char *s)
+cgiFormResultType cgiHtmlEscape(const char *s)
 {
 	return cgiHtmlEscapeData(s, (int) strlen(s));
 }
@@ -2513,7 +2513,7 @@ cgiFormResultType cgiHtmlEscape(char *s)
 	'data' is not null-terminated; 'len' is the number of
 	bytes in 'data'. Returns cgiFormIO in the event
 	of error, cgiFormSuccess otherwise. */
-cgiFormResultType cgiValueEscapeData(char *data, int len)
+cgiFormResultType cgiValueEscapeData(const char *data, int len)
 {
 	while (len--) {
 		if (*data == '\"') {
@@ -2530,7 +2530,7 @@ cgiFormResultType cgiValueEscapeData(char *data, int len)
 	return cgiFormSuccess;
 }
 
-cgiFormResultType cgiValueEscape(char *s)
+cgiFormResultType cgiValueEscape(const char *s)
 {
 	return cgiValueEscapeData(s, (int) strlen(s));
 }

--- a/cgic.h
+++ b/cgic.h
@@ -205,20 +205,20 @@ extern cgiFormResultType cgiFormEntries(
 /* Output string with the <, &, and > characters HTML-escaped. 
 	's' is null-terminated. Returns cgiFormIO in the event
 	of error, cgiFormSuccess otherwise. */
-cgiFormResultType cgiHtmlEscape(char *s);
+cgiFormResultType cgiHtmlEscape(const char *s);
 
 /* Output data with the <, &, and > characters HTML-escaped. 
 	'data' is not null-terminated; 'len' is the number of
 	bytes in 'data'. Returns cgiFormIO in the event
 	of error, cgiFormSuccess otherwise. */
-cgiFormResultType cgiHtmlEscapeData(char *data, int len);
+cgiFormResultType cgiHtmlEscapeData(const char *data, int len);
 
 /* Output string with the " character HTML-escaped, and no
 	other characters escaped. This is useful when outputting
 	the contents of a tag attribute such as 'href' or 'src'.
 	's' is null-terminated. Returns cgiFormIO in the event
 	of error, cgiFormSuccess otherwise. */
-cgiFormResultType cgiValueEscape(char *s);
+cgiFormResultType cgiValueEscape(const char *s);
 
 /* Output data with the " character HTML-escaped, and no
 	other characters escaped. This is useful when outputting
@@ -226,7 +226,7 @@ cgiFormResultType cgiValueEscape(char *s);
 	'data' is not null-terminated; 'len' is the number of
 	bytes in 'data'. Returns cgiFormIO in the event
 	of error, cgiFormSuccess otherwise. */
-cgiFormResultType cgiValueEscapeData(char *data, int len);
+cgiFormResultType cgiValueEscapeData(const char *data, int len);
 
 #endif /* CGI_C */
 


### PR DESCRIPTION
Since there is no change on char to which the parameter points, the const char\* may be better
