### PR TITLE
Changing the type of a local variable

### DIFF
--- a/cgic.c
+++ b/cgic.c
@@ -2441,7 +2441,7 @@ skipSecondValue:
 	e = cgiFormEntryFirst;
 	i = 0;
 	while (e) {
-		int space;
+		size_t space;
 		/* Don't return a field name more than once if
 			multiple values happen to be present for it */
 		pe = cgiFormEntryFirst;
@@ -2451,7 +2451,7 @@ skipSecondValue:
 			}
 			pe = pe->next;					
 		}		
-		space = (int) strlen(e->attr) + 1;
+		space = strlen(e->attr) + 1;
 		stringArray[i] = (char *) malloc(space);
 		if (stringArray[i] == 0) {
 			/* Memory problems */


### PR DESCRIPTION
Changing the local variable type to avoid unnecessary explicit casting
and prevent possible sign conversion

List of affected files:
- cgic.c

List of changes:
- Changed type of space variable "space" from int to size_t
- Removed cast from size_t to int
