### PR TITLE
Temp file as fd and unlink on create

### DIFF
--- a/cgic.c
+++ b/cgic.c
@@ -4,7 +4,7 @@
 /* Used only in Unix environments, in conjunction with mkstemp(). 
 	Elsewhere (Windows), temporary files go where the tmpnam() 
 	function suggests. If this behavior does not work for you, 
-	modify the getTempFileName() function to suit your needs. */
+	modify the getTempFile() function to suit your needs. */
 
 #define cgicTempDir "/tmp"
 
@@ -436,7 +436,7 @@ static void decomposeValue(char *value,
 	char **argValues,
 	int argValueSpace);
 
-static cgiParseResultType getTempFileName(FILE **tFile);
+static cgiParseResultType getTempFile(FILE **tFile);
 
 static cgiParseResultType cgiParsePostMultipartInput() {
 	cgiParseResultType result;
@@ -528,7 +528,7 @@ static cgiParseResultType cgiParsePostMultipartInput() {
 			Otherwise, store to a memory buffer (it is
 			presumably a regular form field). */
 		if (strlen(ffileName)) {
-			if (getTempFileName(&outf) != cgiParseSuccess) {
+			if (getTempFile(&outf) != cgiParseSuccess) {
 				return cgiParseIO;
 			}	
 		} else {
@@ -624,7 +624,7 @@ outOfMemory:
 return cgiParseMemory;
 }
 
-static cgiParseResultType getTempFileName(FILE **tFile)
+static cgiParseResultType getTempFile(FILE **tFile)
 {
 	/* tfileName must be 1024 bytes to ensure adequacy on
 		win32 (1024 exceeds the maximum path length and
@@ -2160,7 +2160,7 @@ cgiEnvironmentResultType cgiReadEnvironment(char *filename) {
 			FILE *out = NULL;
 			int got;
 			int len = e->valueLength;
-			if (getTempFileName(&out)
+			if (getTempFile(&out)
 				!= cgiParseSuccess || !out)
 			{
 				result = cgiEnvironmentIO;

--- a/cgic.c
+++ b/cgic.c
@@ -7,6 +7,7 @@
 	modify the getTempFile() function to suit your needs. */
 
 #define cgicTempDir "/tmp"
+#define cgicMaxTempSize 1073741824
 
 #if CGICDEBUG
 #define CGICDEBUGSTART \
@@ -758,7 +759,10 @@ cgiParseResultType afterNextBoundary(mpStreamPtr mpp, FILE *outf, char **outP,
 			/* Not presently in the middle of a boundary
 				match; just emit the character. */
 			BAPPEND(d[0]);
-		}	
+		}
+		if(outLen > cgicMaxTempSize) {
+			goto outOfMemory;
+		}
 	}
 	/* Read trailing newline or -- EOF marker. A literal EOF here
 		would be an error in the input stream. */


### PR DESCRIPTION
This allows temp files to be automatically deleted when application crashes or closes due to end of stream.