### PR TITLE
Update cgiMain() declaration in cgic.h

### DIFF
--- a/cgic.h
+++ b/cgic.h
@@ -210,7 +210,7 @@ typedef enum {
 extern cgiEnvironmentResultType cgiWriteEnvironment(char *filename);
 extern cgiEnvironmentResultType cgiReadEnvironment(char *filename);
 
-extern int cgiMain();
+extern int cgiMain(void);
 
 extern cgiFormResultType cgiFormEntries(
 	char ***ptrToStringArray);


### PR DESCRIPTION
Prevent applications that compile with `-Wstrict-prototypes` from getting `warning: function declaration isn’t a prototype` when including cgic.h.