### PR TITLE
Fix resource leak after calling cgiMain

### DIFF
--- a/cgic.c
+++ b/cgic.c
@@ -298,6 +298,7 @@ int main(int argc, char *argv[]) {
 	return 0;
 #else
 	result = cgiMain();
+	cgiFreeResources();
 	return result;
 #endif
 }


### PR DESCRIPTION
When handling file upload within cgiMain, the tmp file created by cgic
will never be deleted.

This commit free cgi resources (will delete the tmp file) each time
after calling cgiMain.

Signed-off-by: Ding Tao <i@dingtao.org>